### PR TITLE
terraform: Prevent MongoDB/Elasticsearch instance to be re-spawned if…

### DIFF
--- a/terraform/keymetrics_aio_aws/instance.tf
+++ b/terraform/keymetrics_aio_aws/instance.tf
@@ -22,6 +22,7 @@ resource "aws_instance" "elasticsearch" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["ami"]
   }
   
   security_groups = ["${aws_security_group.elasticsearch.name}"]
@@ -43,6 +44,7 @@ resource "aws_instance" "mongodb" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes = ["ami"]
   }
   
   security_groups = ["${aws_security_group.mongodb.name}"]


### PR DESCRIPTION
… a new AMI is available